### PR TITLE
ci: update messages for pre-commit.ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,8 @@
+ci:
+    autofix_commit_msg: 'chore: auto fixes from pre-commit hooks'
+    autoupdate_commit_msg: 'chore: pre-commit automatic update'
+    autoupdate_schedule: weekly
+
 repos:
 
 - repo: https://github.com/charliermarsh/ruff-pre-commit

--- a/doc/changelog.d/65.maintenance.md
+++ b/doc/changelog.d/65.maintenance.md
@@ -1,0 +1,1 @@
+update messages for pre-commit.ci


### PR DESCRIPTION
As title says - this will prevent failures like the one in #64 