### PR TITLE
fix: remove stubs importer from init file

### DIFF
--- a/.github/workflows/setup-stubs/action.yml
+++ b/.github/workflows/setup-stubs/action.yml
@@ -76,5 +76,6 @@ runs:
         """Patch version for the ansys-mechanical-stubs package."""\n\n''')
 
             for folder in subfolders:
-                f.write(f"from .{folder} import *\n")
-                f.write('"""Mechanical installation version."""\n')
+                if "v" in folder:
+                    f.write(f"from .{folder} import *\n")
+                    f.write('"""Mechanical installation version."""\n')

--- a/doc/changelog.d/78.fixed.md
+++ b/doc/changelog.d/78.fixed.md
@@ -1,0 +1,1 @@
+remove stubs importer from init file


### PR DESCRIPTION
Remove `from .stub_generator import *` from the `__init__.py` file