### PR TITLE
fix: Create stubs one version at a time

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -1,7 +1,16 @@
 name: GitHub CI
 on:
   pull_request:
-  workflow_dispatch:
+  workflow_dispatch: # or workflow_call
+    inputs:
+      mechanical-version:
+        description: "Create stubs for the following Mechanical version:"
+        type: choice
+        options:
+          - '251'
+          - '242'
+          - '241'
+        default: "241" # Make same as DEFAULT_MECHANICAL_VERSION
   push:
     tags:
       - "*"
@@ -10,6 +19,7 @@ on:
 
 env:
   MAIN_PYTHON_VERSION: '3.10'
+  DEFAULT_MECHANICAL_VERSION: '241'
   PACKAGE_NAME: ansys-mechanical-stubs
   PACKAGE_NAMESPACE: ansys.mechanical.stubs
   PACKAGE_PATH: src/ansys/mechanical/stubs
@@ -62,20 +72,41 @@ jobs:
           vale-config: doc/.vale.ini
           token: ${{ secrets.GITHUB_TOKEN }}
 
+  set-mechanical-versions:
+    name: Set Mechanical image and version variables
+    runs-on: ubuntu-latest
+    outputs:
+      # '24.2.0'
+      image: ${{ steps.save-versions.outputs.image }}
+      # '242'
+      version: '${{ steps.save-versions.outputs.version }}'
+    steps:
+      - id: save-versions
+        run: |
+          if [[ -z "${{ inputs.mechanical-version }}" ]]; then
+            export mech_version=${{ env.DEFAULT_MECHANICAL_VERSION }}
+          else
+            export mech_version=${{ inputs.mechanical-version }}
+          fi
+          # Create the image version from the Mechanical version (242 -> 24.2.0)
+          export mech_image_version=${mech_version:0:2}.${mech_version:2}.0
+
+          # Set the image and version variables
+          echo "image=$mech_image_version" >> $GITHUB_OUTPUT
+          echo "version=$mech_version" >> $GITHUB_OUTPUT
+
   gen-stubs:
     name: Generate Mechanical stubs
-    needs: [style, doc-style]
+    needs: [style, doc-style, set-mechanical-versions]
     runs-on: ${{ matrix.os }}
     container:
-      image: ghcr.io/ansys/mechanical:${{ matrix.mechanical.image }}
+      image: ghcr.io/ansys/mechanical:${{ matrix.image }}
       options: --entrypoint /bin/bash
     strategy:
       matrix:
         os: [public-ubuntu-latest-8-cores]
-        mechanical: [
-          { image: '24.1.0', version: '241' },
-          { image: '24.2.0', version: '242' },
-        ]
+        image: ['${{ needs.set-mechanical-versions.outputs.image }}']
+        version: ['${{ needs.set-mechanical-versions.outputs.version }}']
         python-version: ['3.10', '3.11', '3.12']
     steps:
       - name: "Install Git and clone project"
@@ -83,8 +114,8 @@ jobs:
 
       - name: "Install dependencies"
         env:
-          AWP_ROOTDV_DEV: /install/ansys_inc/v${{ matrix.mechanical.version }}
-          ANSYSCL${{ matrix.mechanical.version }}_DIR: /install/ansys_inc/v${{ matrix.mechanical.version }}/licensingclient
+          AWP_ROOTDV_DEV: /install/ansys_inc/v${{ matrix.version }}
+          ANSYSCL${{ matrix.version }}_DIR: /install/ansys_inc/v${{ matrix.version }}/licensingclient
         run: |
           apt update
           apt install --reinstall ca-certificates
@@ -106,8 +137,8 @@ jobs:
 
       - name: "Generate the Mechanical stub files"
         env:
-          AWP_ROOTDV_DEV: /install/ansys_inc/v${{ matrix.mechanical.version }}
-          ANSYSCL${{ matrix.mechanical.version }}_DIR: /install/ansys_inc/v${{ matrix.mechanical.version }}/licensingclient
+          AWP_ROOTDV_DEV: /install/ansys_inc/v${{ matrix.version }}
+          ANSYSCL${{ matrix.version }}_DIR: /install/ansys_inc/v${{ matrix.version }}/licensingclient
         run: |
           python src/ansys/mechanical/stubs/stub_generator/create_files.py > results.txt
         continue-on-error: True
@@ -126,11 +157,11 @@ jobs:
             exit 1
           fi
 
-      - name: "Upload v${{ matrix.mechanical.version }} stubs"
+      - name: "Upload v${{ matrix.version }} stubs"
         uses: actions/upload-artifact@v4
         with:
-          name: v${{ matrix.mechanical.version }}-${{ matrix.python-version }}
-          path: ${{ env.PACKAGE_PATH }}/v${{ matrix.mechanical.version }}
+          name: v${{ matrix.version }}-${{ matrix.python-version }}
+          path: ${{ env.PACKAGE_PATH }}/v${{ matrix.version }}
           retention-days: 7
 
   smoke-tests:

--- a/doc/changelog.d/84.fixed.md
+++ b/doc/changelog.d/84.fixed.md
@@ -1,0 +1,1 @@
+Create stubs one version at a time

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -20,9 +20,9 @@ from ansys.mechanical.stubs import __version__
 project = "ansys.mechanical.stubs"
 copyright = f"(c) {datetime.now().year} ANSYS, Inc. All rights reserved"
 author = "ANSYS Inc."
-release = version = __version__
 cname = os.getenv("DOCUMENTATION_CNAME", default="scripting.mechanical.docs.pyansys.com")
-
+switcher_version = get_version_match(__version__)
+release = version = __version__
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -142,7 +142,7 @@ html_context = {
 html_theme_options = {
     "switcher": {
         "json_url": f"https://{cname}/versions.json",
-        "version_match": get_version_match(version),
+        "version_match": switcher_version,
     },
     "check_switcher": False,
     "github_url": "https://github.com/ansys/pymechanical-stubs",
@@ -161,12 +161,6 @@ html_theme_options = {
             "icon": "fa fa-comment fa-fw",
         },
     ],
-    "use_meilisearch": {
-        "api_key": os.getenv("MEILISEARCH_PUBLIC_API_KEY", ""),
-        "index_uids": {
-            f"pymechanical-stubs-v{get_version_match(version).replace('.', '-')}": "PyMechanical Stubs",
-        },
-    },
     "ansys_sphinx_theme_autoapi": {
         "project": project,
         "templates": "_templates/autoapi",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,8 @@ build-backend = "flit_core.buildapi"
 [project]
 # Check https://flit.readthedocs.io/en/latest/pyproject_toml.html for all available sections
 name = "ansys-mechanical-stubs"
-version = "0.1.dev0"
-description = "PyMechanical scripting API stubs."
+version = "2024.1.dev0"
+description = "Mechanical scripting API stubs for PyMechanical."
 readme = "README.rst"
 requires-python = ">=3.10,<4"
 license = {file = "LICENSE"}


### PR DESCRIPTION
- Create stubs one version at a time, starting with 2024 R1
- The documentation will have a dropdown option equivalent to the Mechanical version. For example, 2024 R1's dropdown would be 2024.1
    - This is similar to how the docs.pyansys.com website is formatted
- Stubs will be released per version, so you can install "ansys-mechanical-stubs==2024.1", for example