### PR TITLE
fix: Add dummy documentation-pdf for the release to pass

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -402,12 +402,18 @@ jobs:
           retention-days: 7
 
       - name: "Create fake PDF"
+        if: |
+          github.event_name == 'workflow_dispatch' ||
+          matrix.python-version == env.MAIN_PYTHON_VERSION
         run: |
           mkdir -p doc/_build/latex
           touch doc/_build/latex/doc.pdf
 
       - name: Upload PDF Documentation
         uses: actions/upload-artifact@v4
+        if: |
+          github.event_name == 'workflow_dispatch' ||
+          matrix.python-version == env.MAIN_PYTHON_VERSION
         with:
           name: documentation-pdf
           path: doc/_build/latex/doc.pdf

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -401,6 +401,18 @@ jobs:
           path: documentation-md
           retention-days: 7
 
+      - name: "Create fake PDF"
+        run: |
+          mkdir -p doc/_build/latex
+          touch doc/_build/latex/doc.pdf
+
+      - name: Upload PDF Documentation
+        uses: actions/upload-artifact@v4
+        with:
+          name: documentation-pdf
+          path: doc/_build/latex/doc.pdf
+          retention-days: 7
+
   clean-docs:
     name: Clean HTML and Markdown documentation
     runs-on: ubuntu-latest

--- a/doc/changelog.d/138.fixed.md
+++ b/doc/changelog.d/138.fixed.md
@@ -1,0 +1,1 @@
+Add a fake documentation-pdf for the release to pass

--- a/doc/changelog.d/138.fixed.md
+++ b/doc/changelog.d/138.fixed.md
@@ -1,1 +1,1 @@
-Add a fake documentation-pdf for the release to pass
+Add dummy documentation-pdf for the release to pass


### PR DESCRIPTION
As title says. Didn't use `code-only` option because the description said it could be used for projects that don't need documentation