### PR TITLE
fix: Correctly order versions in documentation

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -575,14 +575,14 @@ jobs:
           bot-email: ${{ secrets.PYANSYS_CI_BOT_EMAIL }}
           maximum-pr-doc-deployments: 5
 
-      - name: "Install Git and clone project"
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      # - name: "Install Git and clone project"
+      #   uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: "Update gh-pages versions.json"
-        uses: ./.github/workflows/update-gh-pages/
-        with:
-          bot-username: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}
-          bot-email: ${{ secrets.PYANSYS_CI_BOT_EMAIL }}
+      # - name: "Update gh-pages versions.json"
+      #   uses: ./.github/workflows/update-gh-pages/
+      #   with:
+      #     bot-username: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}
+      #     bot-email: ${{ secrets.PYANSYS_CI_BOT_EMAIL }}
 
   build-library:
     name: Build library

--- a/doc/changelog.d/250.fixed.md
+++ b/doc/changelog.d/250.fixed.md
@@ -1,0 +1,1 @@
+Correctly order versions in documentation

--- a/doc/source/_templates/autoapi/index.rst
+++ b/doc/source/_templates/autoapi/index.rst
@@ -10,7 +10,7 @@ descriptions of the objects, methods, and properties for all namespaces.
    :titlesonly:
    :maxdepth: 3
 
-   {% for page in pages %}
+   {% for page in pages | sort(attribute='name', reverse=true) %}
    {% if (page.top_level_object or page.name.split('.') | length == 4) and page.display %}
    {% if page.name.startswith("ansys.mechanical.stubs.v") %}
    {% set page_name = page.name.split('.')|list %}


### PR DESCRIPTION
Fix the order of the versions in the documentation, so it's displayed from top to bottom as 2026 R1, 2025 R2, 2025 R1, 2024 R2